### PR TITLE
Typo in Installation Directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project will contain all Firebase-related modules for Analytics, Cloud-Mess
 3. Unpack them to your project directory
 4. Configure your Firebase project
  - iOS: Download the `GoogleConfig-Info.plist` from your project and copy it to `Resources` (classic) or `app/assets/iphone` (Alloy)
- - Android: Download the `google-services.json` and copy it to `Resources` (classic) or `app/assets/iphone` (Alloy)
+ - Android: Download the `google-services.json` and copy it to `Resources` (classic) or `app/assets/android` (Alloy)
 5. Require the your modules and call the `configure` method to configure your Firebase application:
 ```js
 var FirebaseCore = require('firebase.core');


### PR DESCRIPTION
Small typo in the 4th step of installation. For Android, google-services.json should be put in 'app/assets/android', not 'app/assets/ios' inside Alloy projects. Kind of self explanatory given iOS above, but might needlessly confuse some.